### PR TITLE
feat: add --detailed-policies-eval parameter support

### DIFF
--- a/sysdig-cli-scan-task/src/InputFetch.ts
+++ b/sysdig-cli-scan-task/src/InputFetch.ts
@@ -64,6 +64,10 @@ export class InputFetch {
         return this.fetchString('policy', false);
     }
 
+    get detailedPoliciesEval(): boolean {
+        return tl.getBoolInput('detailedPoliciesEval');
+    }
+
     private error(input: string, required: boolean): string {
         if (required) {
             tl.setResult(tl.TaskResult.Failed, input.toUpperCase().concat(' fetch failed.'));

--- a/sysdig-cli-scan-task/src/ScanningEngine.ts
+++ b/sysdig-cli-scan-task/src/ScanningEngine.ts
@@ -79,6 +79,11 @@ export function buildScanningEngineArg(binaryPath: string): tr.ToolRunner {
   if (fetch.policy) {
     scanningEngine.arg(['--policy=' + fetch.policy]);
   }
+
+  if (fetch.detailedPoliciesEval) {
+    scanningEngine.arg('--detailed-policies-eval');
+  }
+
   // Add image to be scanned
   scanningEngine.arg(fetch.image);
 

--- a/sysdig-cli-scan-task/task.json
+++ b/sysdig-cli-scan-task/task.json
@@ -132,6 +132,15 @@
       "required": false,
       "helpMarkDown": "Policy to evaluate in the pipeline execution. If not specified, only the Always Apply policy will be evaluated.",
       "groupName": "overrides"
+    },
+    {
+      "name": "detailedPoliciesEval",
+      "type": "boolean",
+      "label": "Show detailed policies evaluation results",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "Show detailed per-policy evaluation results in the output.",
+      "groupName": "overrides"
     }
   ],
   "execution": {


### PR DESCRIPTION
## Summary

- Adds a new `detailedPoliciesEval` boolean input to the Azure DevOps task
- When enabled, passes `--detailed-policies-eval` to the Sysdig CLI scanner
- Available under "Additional Options" in the task configuration

## Changes

- `task.json` - new input definition
- `InputFetch.ts` - new getter
- `ScanningEngine.ts` - passes flag to CLI scanner

## Test plan

- [ ] Configure task with `detailedPoliciesEval: true`, verify `--detailed-policies-eval` is passed to the CLI scanner
- [ ] Configure task without the option, verify default behavior unchanged

Resolves ET-821.